### PR TITLE
Remove redundant `git` installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN apt update && \
 ADD . /neon_enclosure
 WORKDIR /neon_enclosure
 
-RUN apt install git
-
 RUN pip install wheel && \
     pip install .[docker]
 


### PR DESCRIPTION
# Description
Removes extra step in Dockerfile

# Issues
https://github.com/NeonGeckoCom/neon_enclosure/pull/76

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->