### PR TITLE
Patch ovos-backend-client Stable Release Compatibility

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,5 +6,5 @@ click-default-group~=1.2
 ovos-bus-client~=0.0.4
 
 # TODO: Patching ovos_PHAL inherited dependencies
-ovos_backend_client~=0.0.6
+ovos-backend-client>=0.0.6,<1.0.0
 mycroft-messagebus-client~=0.10

--- a/version.py
+++ b/version.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"


### PR DESCRIPTION
# Description
Patch ovos backend client compat to allow 0.1
Part of planning a [stable NeonCore release](https://github.com/NeonGeckoCom/NeonCore/actions/runs/8023894831/job/21921307354?pr=618) that supports the latest ovos-workshop

# Issues
Port of https://github.com/NeonGeckoCom/neon_enclosure/pull/82

# Other Notes
Following this PR, Merge `master` into `dev`, incrementing the version to `a1`
Workflow validated https://github.com/NeonGeckoCom/neon_audio/pull/166