### PR TITLE
fix: use new path for get_mycroft_bus

### DIFF
--- a/neon_enclosure/__main__.py
+++ b/neon_enclosure/__main__.py
@@ -29,7 +29,7 @@
 from neon_utils.log_utils import init_log
 from neon_utils.process_utils import start_malloc, snapshot_malloc, print_malloc
 from neon_utils.signal_utils import init_signal_bus, init_signal_handlers
-from ovos_utils.messagebus import get_mycroft_bus
+from ovos_bus_client.util import get_mycroft_bus
 from ovos_utils.process_utils import reset_sigint_handler, PIDLock
 from ovos_utils.log import LOG
 from ovos_utils import wait_for_exit_signal


### PR DESCRIPTION
# Description
Use new path for get_mycroft_bus, to support ovos-utils 0.1.0+
