### PR TITLE
Update plugin load to respect explicitly disabled plugins

### DIFF
--- a/neon_enclosure/service.py
+++ b/neon_enclosure/service.py
@@ -61,26 +61,6 @@ class NeonHardwareAbstractionLayer(PHAL):
         LOG.info(f"Started PHAL")
         self.started.set()
 
-    def load_plugins(self):
-        for name, plug in find_phal_plugins().items():
-            LOG.info(f"Loading {name}")
-            config = self.user_config.get(name) or {}
-            try:
-                if hasattr(plug, "validator"):
-                    enabled = plug.validator.validate(config)
-                else:
-                    enabled = config.get("enabled")
-            except Exception as e:
-                LOG.exception(e)
-                enabled = False
-            if enabled:
-                try:
-                    self.drivers[name] = plug(bus=self.bus, config=config)
-                    LOG.info(f"PHAL plugin loaded: {name}")
-                except Exception:
-                    LOG.exception(f"failed to load PHAL plugin: {name}")
-                    continue
-
     def shutdown(self):
         LOG.info("Shutting Down")
         try:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-phal==0.0.5a15
+ovos-phal~=0.0.4,>=0.0.5a15
 neon-utils[network]~=1.9
 ovos_utils~=0.0,>=0.0.32
 click~=8.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-phal~=0.0.4,>=0.0.5a15
+ovos-phal~=0.0.4,>=0.0.5a17
 neon-utils[network]~=1.9
 ovos_utils~=0.0,>=0.0.32
 click~=8.0


### PR DESCRIPTION
# Description
Removes `load_plugins` override method
Updates ovos-PHAL dependency to include updated plugin load logic

# Issues
Implements https://github.com/OpenVoiceOS/ovos-PHAL/pull/35

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->